### PR TITLE
Allow functions to return static params directly

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,7 +32,7 @@ end
 function flatten(xs)
     res = []
     for x in xs
-        push!(res, x...)
+        append!(res, x)
     end
     return res
 end

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -203,6 +203,16 @@ inc_val(::Val{N}) where N = N + 1
     @test play!(tape, inc_val, Val(42)) == inc_val(Val(2))
 end
 
+static_val(::Val{N}) where {N} = N
+
+@testset "trace: returning :static_parameter" begin
+    val, tape = trace(static_val, Val(2))
+    @test val == static_val(Val(2))
+    # note: static parameter is recorded as constant
+    # so changing value on tape has no effect
+    @test play!(tape, static_val, Val(42)) == 2
+end
+
 
 ###############################################################################
 


### PR DESCRIPTION
- Allow functions to return static params directly
- Prevent splatting in flatten
