### PR TITLE
Switch `__new__` to a macro

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,7 @@ without default constructors, closures, etc.
     @splatnew(T, args)
 end
 
-macro __splatnew__(T, args)
+macro splatnew(T, args)
     esc(Expr(:splatnew, T, args))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,7 +4,7 @@ User-level version of the `new()` pseudofunction.
 Can be used to construct most Julia types, including structs
 without default constructors, closures, etc.
 """
-function __new__(T, args...)
+@inline function __new__(T, args...)
     @splatnew(T, args)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,10 +4,13 @@ User-level version of the `new()` pseudofunction.
 Can be used to construct most Julia types, including structs
 without default constructors, closures, etc.
 """
-@generated function __new__(T, args...)
-    return Expr(:splatnew, :T, :args)
+function __new__(T, args...)
+    @splatnew(T, args)
 end
 
+macro __splatnew__(T, args)
+    esc(Expr(:splatnew, T, args))
+end
 
 """
 Unwrap constant value from its expression container such as

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,7 @@
+macro __splatnew__(T, args)
+    esc(Expr(:splatnew, T, args))
+end
+
 """
     __new__(T, args...)
 User-level version of the `new()` pseudofunction.
@@ -5,11 +9,7 @@ Can be used to construct most Julia types, including structs
 without default constructors, closures, etc.
 """
 @inline function __new__(T, args...)
-    @splatnew(T, args)
-end
-
-macro splatnew(T, args)
-    esc(Expr(:splatnew, T, args))
+    @__splatnew__(T, args)
 end
 
 """


### PR DESCRIPTION
Same idea as https://github.com/FluxML/Zygote.jl/pull/1220. Using a generated function here should just introduce unnecessary compilation overhead when a macro can do the same job with significantly less overhead. 