### PR TITLE
Don't treat `missing` as a special value.

### DIFF
--- a/test/test_tape.jl
+++ b/test/test_tape.jl
@@ -27,7 +27,7 @@ import Umlaut: Tape, V, inputs!, rebind!, mkcall, primitivize!
     c = mkcall(*, 2.0, v1)                # bound var
     @test c.val == 2.0 * tape[v1].val
     c = mkcall(*, 2.0, V(100))            # unbound var
-    @test c.val === missing
+    @test c.val === Umlaut.UncalculatedValue()
     c = mkcall(*, 2.0, V(100); val=10.0)  # manual value
     @test c.val == 10.0
 

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -486,3 +486,11 @@ end
     @test tape.c.count == 4
     @test count(op -> op isa Call && op.fn == (+), tape) == 4
 end
+
+###############################################################################
+
+@testset "passing missing as argument" begin
+    res, _ = trace(ismissing, missing)
+    @test !ismissing(res)
+    @test res === true
+end


### PR DESCRIPTION
Hi! I had an issue when tracing function calls which return/take `missing` values as argument since the `missing` value would propagate. See for example this test which fail on Umlaut#main:

https://github.com/dfdx/Umlaut.jl/blob/6db39ad0d0f5a65bd844c844f87eea52b3243d3b/test/test_trace.jl#L492-L496

Instead of using `missing`, this commit introduces a new type `Umlaut.UncalculatedValue()` which should be used instead to signal an uncalculated value which will then propagate. This pattern is similar to the one used for the `init` keyword in reductions in Julia Base (see [`Base._InitialValue()`](https://github.com/JuliaLang/julia/blob/441c57057306ec63ed874e610bc53ba2a145c17e/base/reduce.jl#L175)).

I understand that this change is a breaking change since the API of `mkcall` has basically changed w.r.t its parameters so I am open to other any ideas to mitigate this problem. Thanks :wave: