### PR TITLE
Improve error message

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -241,7 +241,7 @@ function getcode(f, argtypes)
     @assert !isempty(irs) "No IR found for $f($argtypes...)"
     @assert length(irs) == 1 "More than one IR found for $f($argtypes...)"
     @assert irs[1] isa Pair{IRCode, <:Any} "Expected Pair{IRCode,...}, " *
-            "but got $(typeof(irs[1])) instead"
+            "but got $(typeof(irs[1])) instead for f=$f with argtypes=$argtypes"
     return irs[1][1]
 end
 


### PR DESCRIPTION
I noticed that it is currently a little tricky to figure out which function things fall over for when you e.g. hit built-in function that has not been marked as primitive.

This extends the error message slightly to make it clearer what has gone wrong.