### PR TITLE
gotoifnot handle

### DIFF
--- a/src/trace.jl
+++ b/src/trace.jl
@@ -433,6 +433,32 @@ function group_varargs!(t::Tracer, v_fargs)
     return (v_f, v_args...)
 end
 
+"""
+    handle_gotoifnot_node!(t::Tracer, cf::Core.GotoIfNot, frame::Frame)
+
+Must return the value associated to a `Core.GotoIfNot` node.
+May also have side-effects, such as modifying the tape.
+"""
+function handle_gotoifnot_node!(t::Tracer, cf::Core.GotoIfNot, frame::Frame)
+    return if cf.cond isa Argument || cf.cond isa SSAValue
+        # resolve tape var
+        t.tape[frame.ir2tape[cf.cond]].val
+    elseif cf.cond isa Bool
+        # literal condition (e.g. while true)
+        cf.cond
+    elseif cf.cond == Expr(:boundscheck)
+        # boundscheck expression must be evaluated on some later stage
+        # of interpretation that we don't have access to on this level
+        # so just skipping the check instead
+        true
+    else
+        exc = AssertionError(
+            "Expected goto condition to be of type Argument, " *
+            "SSAValue or Bool, but got $(cf.cond). \n\nFull IR: \n\n$(ir)\n"
+        )
+        throw(exc)
+    end
+end
 
 """
     trace!(t::Tracer, v_fargs)
@@ -458,25 +484,10 @@ function trace!(t::Tracer, v_fargs)
             prev_bi = bi
             bi += 1
         elseif cf isa Core.GotoIfNot
+
             # conditional jump
-            cond_val = if cf.cond isa Argument || cf.cond isa SSAValue
-                # resolve tape var
-                t.tape[frame.ir2tape[cf.cond]].val
-            elseif cf.cond isa Bool
-                # literal condition (e.g. while true)
-                cf.cond
-            elseif cf.cond == Expr(:boundscheck)
-                # boundscheck expression must be evaluated on some later stage
-                # of interpretation that we don't have access to on this level
-                # so just skipping the check instead
-                true
-            else
-                exc = AssertionError(
-                    "Expected goto condition to be of type Argument, " *
-                    "SSAValue or Bool, but got $(cf.cond). \n\nFull IR: \n\n$(ir)\n"
-                )
-                throw(exc)
-            end
+            cond_val = handle_gotoifnot_node!(t, cf, frame)
+
             # if not cond, set i to destination, otherwise step forward
             prev_bi = bi
             bi = !cond_val ? cf.dest : bi + 1


### PR DESCRIPTION
Proposal for just making a generic handler for `GotoIfNot`, which defaults to doing what it currently does. Lets the pass-author produce context-specific behaviour by dispatching on the first type parameter of `t`.

I'm very much open to changing this if it's not what you were imagining @dfdx 