### PR TITLE
Fixes for 1.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -237,7 +237,11 @@ Tracer(tape::Tape{C}) where C = Tracer{C}(tape, [])
 
 
 function getcode(f, argtypes)
-    irs = code_ircode_by_signature(no_pass, Tuple{Core.Typeof(f), argtypes...})
+    irs = @static if VERSION < v"1.8"
+        code_ircode_by_signature(no_pass, Tuple{Core.Typeof(f), argtypes...})
+    else
+        Base.code_ircode(f, argtypes; optimize_until="slot2reg")
+    end
     @assert !isempty(irs) "No IR found for $f($argtypes...)"
     @assert length(irs) == 1 "More than one IR found for $f($argtypes...)"
     @assert irs[1] isa Pair{IRCode, <:Any} "Expected Pair{IRCode,...}, " *

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -237,7 +237,7 @@ Tracer(tape::Tape{C}) where C = Tracer{C}(tape, [])
 
 
 function getcode(f, argtypes)
-    irs = @static if VERSION < v"1.8"
+    irs = @static if VERSION < v"1.9"
         code_ircode_by_signature(no_pass, Tuple{Core.Typeof(f), argtypes...})
     else
         Base.code_ircode(f, argtypes; optimize_until="slot2reg")


### PR DESCRIPTION
Sorry for _another_ PR @dfdx . Currently Umlaut doesn't work on 1.9 because `CompilerPluginTools` doesn't work on 1.9. @Roger-luo pointed out to me that things have changed quite a bit in 1.9, and there's now the helpful `code_ircode` function in `Base`, which does exactly what we want here (I think).

I chose the `optimize_until` kwarg based on the optimisation levels available [here](https://github.com/JuliaLang/julia/blob/8e630552924eac54c809aa7bc30871c7df1582d3/base/compiler/optimize.jl#L548), and which level made the tests pass (I think the one I've chosen must be equivalent to the `no_pass` setting for `CompilerPluginTools`.