### PR TITLE
gc preserve statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -260,7 +260,6 @@ macro getcode(ex)
     end
 end
 
-
 function rewrite_special_cases(st::Expr)
     ex = Meta.isexpr(st, :(=)) ? st.args[2] : st
     if Meta.isexpr(ex, :new)
@@ -358,7 +357,9 @@ function trace_block!(t::Tracer, ir::IRCode, bi::Integer, prev_bi::Integer, spar
         elseif Meta.isexpr(ex, :static_parameter)
             sv = SSAValue(pc)
             frame.ir2tape[sv] = sparams[ex.args[1]]
-        elseif ex isa Expr && ex.head in [:code_coverage_effect]
+        elseif ex isa Expr && ex.head in [
+            :code_coverage_effect, :gc_preserve_begin, :gc_preserve_end,
+        ]
             # ignored expressions, just skip it
         elseif ex isa Expr
             error("Unexpected expression: $ex\nFull IRCode:\n\n $ir")

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -260,6 +260,7 @@ macro getcode(ex)
     end
 end
 
+
 function rewrite_special_cases(st::Expr)
     ex = Meta.isexpr(st, :(=)) ? st.args[2] : st
     if Meta.isexpr(ex, :new)


### PR DESCRIPTION
Ensures that Umlaut can handle `:gc_preserve_begin` and `:gc_preserve_end`.

I _believe_ that it turns out that just skipping them is fine because, in both interpreted and compiled settings, we keep around references to everything on the tape, so there's no chance of losing the objects that would otherwise require careful preservation. If you can think of a way in which this might fail to be the case, I'd be very interested to hear about it!