### PR TITLE
Add foreigncall support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.5.3"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"
+ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1.6"
 CompilerPluginTools = "0.1.9"
+ExprTools = "0.1"
+julia = "1.6"

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,8 +1,8 @@
 Base.Experimental.@compiler_options optimize=0 compile=min infer=no
 
 import Core: CodeInfo, SSAValue, SlotNumber
-import Statistics, LinearAlgebra   # include primitives from these stanard modules
-using CompilerPluginTools
+import Statistics, LinearAlgebra   # include primitives from these standard modules
+using CompilerPluginTools, ExprTools
 
 
 include("utils.jl")

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -415,6 +415,7 @@ function extract_foriegncall_name(v::Tuple)
     return Val((Symbol(v[1]), Symbol(v[2])))
 end
 
+# adapted from https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/aefaa300746b95b75f99d944a61a07a8cb145ef3/src/optimize.jl#L239
 function interpolate_sparams(@nospecialize(t::Type), sparams::Dict)
     t isa Core.TypeofBottom && return t
     while t isa UnionAll

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -371,6 +371,10 @@ function trace_block!(t::Tracer, ir::IRCode, bi::Integer, prev_bi::Integer, spar
             sv = SSAValue(pc)
             frame.ir2tape[sv] = sparams[ex.args[1]]
         elseif Meta.isexpr(ex, :foreigncall)
+            @static if VERSION < v"1.9"
+                throw(error("foreigncall not supported on versions less than 1.9"))
+            end
+
             vs = resolve_tape_vars(frame, ex.args...)
 
             # Extract arguments.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,7 +30,8 @@ becomes
 ```julia
 __foreigncall__(Val(:foo), Val(Tout), (Val(A), Val(B)), Val(nreq), Val(:ccall), args...)
 ```
-Please consult the Julia documentation for more information on how foreigncall nodes work.
+Please consult the Julia documentation for more information on how foreigncall nodes work,
+and consult this package's tests for examples.
 """
 @generated function __foreigncall__(
     ::Val{name}, ::Val{RT}, AT::Tuple, ::Val{nreq}, ::Val{calling_convention}, x...

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using Umlaut
+using LinearAlgebra
 
 include("test_utils.jl")
 include("test_tape.jl")

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -128,7 +128,6 @@ end
 
 ###############################################################################
 
-
 # No static parameters.
 function foreigncall_0(x::Array{Float64})
     return unsafe_load(ccall(:jl_array_ptr, Ptr{Float64}, (Any, ), x))
@@ -162,16 +161,18 @@ function foreigncall_blas_1(n::Int, DA::T, DX::Array{T}, incx::Int) where {T}
     return DX
 end
 
-@testset "trace: foreigncall" begin
-    @testset "$f" for (f, args) in [
-        (foreigncall_0, (randn(5), )),
-        (foreigncall_1, (Ptr{Float64}, randn(5))),
-        (foreigncall_blas_0, (5, 3.0, randn(11), 2)),
-        (foreigncall_blas_1, (5, 3.0, randn(11), 2)),
-    ]
-        original_args = deepcopy(args)
-        val, tape = trace(f, args...)
-        @test val == f(deepcopy(original_args)...)
+@static if VERSION >= v"1.9"
+    @testset "trace: foreigncall" begin
+        @testset "$f" for (f, args) in [
+            (foreigncall_0, (randn(5), )),
+            (foreigncall_1, (Ptr{Float64}, randn(5))),
+            (foreigncall_blas_0, (5, 3.0, randn(11), 2)),
+            (foreigncall_blas_1, (5, 3.0, randn(11), 2)),
+        ]
+            original_args = deepcopy(args)
+            val, tape = trace(f, args...)
+            @test val == f(deepcopy(original_args)...)
+        end
     end
 end
 


### PR DESCRIPTION
This one is slightly more complicated unfortunately. I've had to add a dependency on `ExprTools` as it was necessary to get hold of the names of static parameters, as these sometimes appear in foreigncall expressions, and it's necessary to replace them with their values.