### PR TITLE
Loopinfo support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -389,7 +389,7 @@ function trace_block!(t::Tracer, ir::IRCode, bi::Integer, prev_bi::Integer, spar
                 mkcall(__foreigncall__, name, RT, AT, nreq, calling_convention, x...),
             )
         elseif ex isa Expr && ex.head in [
-            :code_coverage_effect, :gc_preserve_begin, :gc_preserve_end,
+            :code_coverage_effect, :gc_preserve_begin, :gc_preserve_end, :loopinfo,
         ]
             # ignored expressions, just skip it
         elseif ex isa Expr

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -105,7 +105,7 @@ function without_preservation()
     return unsafe_load(ptr)
 end
 
-@testset "gc_preserve" begin
+@testset "trace: gc_preserve" begin
     @testset "with preservation" begin
         @test with_preservation() == false
         val, tape = trace(with_preservation; ctx=GCCtx())
@@ -174,6 +174,19 @@ end
             @test val == f(deepcopy(original_args)...)
         end
     end
+end
+
+###############################################################################
+
+@eval function foo(x)
+    $(Expr(:loopinfo, Symbol("julia.simd"), nothing))
+    return 5x
+end
+
+@testset "trace: :loopinfo" begin
+    val, tape = trace(foo, 5.0)
+    @test val == foo(5.0)
+    @test play!(tape, foo, 5.0) == val
 end
 
 ###############################################################################


### PR DESCRIPTION
It appears that a `:loopinfo` node (see test for example) is another thing that can appear in Julia IR 🤷 

I've only seen it used to indicate to the compiler something to do with simd, and have checked that the JuliaInterpreter handles it in the same way that I propose to do here (i.e. by ignoring it) -- see https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/aefaa300746b95b75f99d944a61a07a8cb145ef3/src/interpret.jl#L403