### PR TITLE
Tweak splatting implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Umlaut = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
+
+[compat]
+Documenter = "0.27"

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -500,7 +500,7 @@ function unsplat!(t::Tracer, v_fargs)
                 push!(actual_v_args, iter.args...)
             else
                 for i in eachindex(iter.val)
-                    x = push!(t.tape, mkcall(getindex, v, i; line="Umlaut.unsplat!"))
+                    x = push!(t.tape, mkcall(getfield, v, i; line="Umlaut.unsplat!"))
                     push!(actual_v_args, x)
                 end
             end

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -301,8 +301,8 @@ multiarg_fn(x, y, z) = x + y + z
     f = t -> multiarg_fn(t...)
     _, tape = trace(f, (1, 2))
     @test play!(tape, f, (3, 4)) == f((3, 4))
-    @test tape[V(4)].fn == Base.getindex
-    @test tape[V(5)].fn == Base.getindex
+    @test tape[V(4)].fn == Base.getfield
+    @test tape[V(5)].fn == Base.getfield
 
     @test_logs (:warn, "Variable %2 had length 2 during tracing, but now has length 3") play!(tape, f, (5, 6, 7))
 


### PR DESCRIPTION
Splatting currently uses `getindex` calls in its implementation in Umlaut. Unfortunately, I'm using a context in which `getindex` is not a primitive. I could always primitivize my tape, but that involves unnecessary work, and (anecdotally) appears to add quite a few additional operations to the tape.

`getfield` works just as well as `getindex` for this task, but has the advantage that it must be primitive in any context, because it is a built-in, meaning that there is no IR to look up.

So this PR changes `getindex` to `getfield`.