### PR TITLE
Towards fixing splatting properly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Umlaut"
 uuid = "92992a2b-8ce5-4a9c-bb9d-58be9a7dc841"
 authors = ["Andrei Zhabinski <andrei.zhabinski@gmail.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 CompilerPluginTools = "6b7a57c9-7cc1-4fdf-b7f5-e857abae3638"

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -473,6 +473,10 @@ function code_signature(ctx, v_fargs)
     return fargtypes
 end
 
+__to_tuple__(x::Tuple) = x
+__to_tuple__(x::NamedTuple) = Tuple(x)
+__to_tuple__(x::Array) = Tuple(x)
+__to_tuple__(x) = __to_tuple__(collect(x))
 
 """
     unsplat!(t::Tracer, v_fargs)
@@ -497,8 +501,10 @@ function unsplat!(t::Tracer, v_fargs)
             if is_tuple
                 push!(actual_v_args, iter.args...)
             else
-                for i in eachindex(iter.val)
-                    x = push!(t.tape, mkcall(getfield, v, i; line="Umlaut.unsplat!"))
+                tuple_v = push!(t.tape, mkcall(__to_tuple__, v; line="Umlaut.unsplat!"))
+                iter = t.tape[tuple_v].val
+                for i in eachindex(iter)
+                    x = push!(t.tape, mkcall(getfield, tuple_v, i; line="Umlaut.unsplat!"))
                     push!(actual_v_args, x)
                 end
             end

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -301,8 +301,8 @@ multiarg_fn(x, y, z) = only(x) + only(y) + only(z)
     f = t -> multiarg_fn(t...)
     _, tape = trace(f, (1, 2))
     @test play!(tape, f, (3, 4)) == f((3, 4))
-    @test tape[V(6)].fn == Base.getfield
-    @test tape[V(7)].fn == Base.getfield
+    @test tape[V(4)].fn == Base.getfield
+    @test tape[V(5)].fn == Base.getfield
 
     @test_logs (:warn, "Variable %2 had length 2 during tracing, but now has length 3") play!(tape, f, (5, 6, 7))
 
@@ -311,7 +311,8 @@ multiarg_fn(x, y, z) = only(x) + only(y) + only(z)
     _, tape = trace(f, 1)
     @test play!(tape, f, 2) == f(2)
     v2 = V(tape, 2)
-    @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, V(tape, 6)])
+    v6 = V(tape, 6)
+    @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, v6])
 
     test_f = x -> multiarg_fn(x...)
     @testset "$name" for (name, x) in [
@@ -320,6 +321,7 @@ multiarg_fn(x, y, z) = only(x) + only(y) + only(z)
         ("splat Vector{Float64}", [1.0, 2.0]),
         ("splat zip", zip([1.0, 2.0, 3.0])),
     ]
+        @test test_f(x) === test_f(x)
         v, tape = trace(test_f, x)
         @test v == test_f(x)
     end

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -275,9 +275,9 @@ function vararg_fn(x, xs...)
     return x + sum(xs)
 end
 
-multiarg_fn(x) = x
-multiarg_fn(x, y) = x + y
-multiarg_fn(x, y, z) = x + y + z
+multiarg_fn(x) = only(x)
+multiarg_fn(x, y) = only(x) + only(y)
+multiarg_fn(x, y, z) = only(x) + only(y) + only(z)
 
 
 @testset "trace: varargs, splatting" begin
@@ -301,8 +301,8 @@ multiarg_fn(x, y, z) = x + y + z
     f = t -> multiarg_fn(t...)
     _, tape = trace(f, (1, 2))
     @test play!(tape, f, (3, 4)) == f((3, 4))
-    @test tape[V(4)].fn == Base.getfield
-    @test tape[V(5)].fn == Base.getfield
+    @test tape[V(6)].fn == Base.getfield
+    @test tape[V(7)].fn == Base.getfield
 
     @test_logs (:warn, "Variable %2 had length 2 during tracing, but now has length 3") play!(tape, f, (5, 6, 7))
 
@@ -311,8 +311,18 @@ multiarg_fn(x, y, z) = x + y + z
     _, tape = trace(f, 1)
     @test play!(tape, f, 2) == f(2)
     v2 = V(tape, 2)
-    @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, 1])
+    @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, V(tape, 6)])
 
+    test_f = x -> multiarg_fn(x...)
+    @testset "$name" for (name, x) in [
+        ("splat single Int", 1),
+        ("splat single Float64", 1.0),
+        ("splat Vector{Float64}", [1.0, 2.0]),
+        ("splat zip", zip([1.0, 2.0, 3.0])),
+    ]
+        v, tape = trace(test_f, x)
+        @test v == test_f(x)
+    end
 end
 
 

--- a/test/test_trace.jl
+++ b/test/test_trace.jl
@@ -322,7 +322,9 @@ multiarg_fn(x, y, z) = only(x) + only(y) + only(z)
     @test play!(tape, f, 2) == f(2)
     v2 = V(tape, 2)
     v6 = V(tape, 6)
-    @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, v6])
+    if VERSION >= v"1.9"
+        @test (tape[V(end)].fn == +) && (tape[V(end)].args == [v2, v2, v6])
+    end
 
     test_f = x -> multiarg_fn(x...)
     @testset "$name" for (name, x) in [


### PR DESCRIPTION
It turns out that while #48 didn't break any of the tests in Umlaut, it did break some examples of splatting in code that I'm testing on. This lead me to dig around a little, and construct the additional test cases for Umlaut that I've added in this PR.

Notably:
1. the current implementation fails when you splat any data type which doesn't support `getfield` -- this is most things other than `Tuple` and `NamedTuple`.
2. the previous implementation worked for anything for which `getindex` works, which is a greater array of things than `getfield`
3. the previous implementation fails for iterators which don't have `getindex` defined on them. I've created one of these by adding a test involving a `zip`, for which `getindex` doesn't work.

I'm not entirely sure what the right answer is here. I would really rather not revert to the `getindex` implementation of `unsplat!`, because it puts a (potentially) non-primitive on the tape, and doesn't handle all of the cases.

One option is to, in the general case, insert a `Core._apply_iterate(itr, tuple, x...)` onto the tape, which will output a `Tuple` -- we could then employ the current strategy on that `Tuple` (`getfield` calls etc). This is a little bit annoying, but it at least has the property that it should handle every case. Downstream consumers of the tapes produced by `Umlaut` could then handle whichever range of options they prefer. We could then add special handlers for `Tuple`s, `Vector`s`, etc.

What are your thoughts @dfdx ?

